### PR TITLE
Add legacy webhook signature support for time-based signatures

### DIFF
--- a/src/VerifyRequest.php
+++ b/src/VerifyRequest.php
@@ -33,7 +33,31 @@ class VerifyRequest
     {
         $expected = $this->computeExpectedHash($request);
 
-        return $expected === $this->headerSignature;
+        if ($expected === $this->headerSignature) {
+            return true;
+        }
+
+        return $this->validateLegacy($request);
+    }
+
+    /**
+     * Validate Legacy Request (with time component)
+     *
+     * @param array $request
+     * @return bool
+     */
+    private function validateLegacy(array $request): bool
+    {
+        $signature = explode(',', $this->headerSignature);
+        $time = $signature[0] ?? null;
+
+        if ($time === null || count($signature) < 2) {
+            return false;
+        }
+
+        $expected = hash('SHA256', $this->webhookSignature.$time.json_encode($request));
+
+        return in_array($expected, $signature, true);
     }
 
 

--- a/tests/VerifyRequestTest.php
+++ b/tests/VerifyRequestTest.php
@@ -36,6 +36,22 @@ class VerifyRequestTest extends TestCase
         );
     }
 
+    /** @test **/
+    public function can_verify_legacy_request_signature_with_time(): void
+    {
+        $json = '{"event":"order.complete","created":1656066775,"live":true,"version":"v4.12.15","data":{"order_id":7290109,"hash":"eyJpdiI6ImJSMGgwMHI3cEZcL00xS0hwTk5WaHdnPT0iLCJ2YWx1ZSI6IkFmaUNZdHdET1JRbFdiYzQ1b2o5UGc9PSIsIm1hYyI6ImUzYjFkODMxZTZlZTYwOTE3ZGIyZjUwYTk2NjEwMzg0MmM5ZGY4YTljZDExMjhhZDNiOWE2NGIwNWZiNjlkMjkifQ=="}}';
+        $request = json_decode($json, true);
+
+        $webhookSignature = 'Yih7Ry8MkNaFPfzv6S4ZMCMC59FWMfQl';
+        $time = '1656066775';
+        $hash = hash('SHA256', $webhookSignature.$time.json_encode($request));
+        $headerSignature = $time.','.$hash;
+
+        $validator = new VerifyRequest($webhookSignature, $headerSignature);
+
+        $this->assertTrue($validator->validates($request));
+    }
+
     /** @test */
     public function invalid_requests_return_as_invalid(): void
     {


### PR DESCRIPTION
## Summary
- Updates `VerifyRequest::validates()` to support both current and legacy webhook signature formats
- Legacy webhooks were created with a `time,hash` format (`webhookSignature + time + payload`), but the current implementation only validates using `webhookSignature + payload`
- The method now tries the current format first, then falls back to the legacy `time,hash` format
- Adds test coverage for legacy signature validation

## Test plan
- [x] Existing tests pass (new signatures still validate correctly)
- [x] New test verifies legacy `time,hash` signatures validate correctly
- [x] Invalid signatures still return false